### PR TITLE
[AltJIT] Specify pre-installed version of python3

### DIFF
--- a/how-to-use-altstore/altjit.md
+++ b/how-to-use-altstore/altjit.md
@@ -60,7 +60,7 @@ sudo touch /Library/Developer/CommandLineTools/.beta
 
 ```
 brew install openssl@3 
-python3 -m pip install -U pymobiledevice3
+/usr/bin/python3 -m pip install -U pymobiledevice3
 ```
 
 5. Connect your device to your Mac via lightning/USB-C. **Enabling JIT via WiFi is not yet supported**


### PR DESCRIPTION
If someone already has Homebrew and a version of Python 3 installed from it, the `python3` and/or `pip` commands will install `pymobiledevice3` to the Homebrew Python path. AltJIT uses the built-in macOS version of `python3` in `/usr/bin`. Updating the command to specify this won't break it for people who don't use Homebrew versions of Python, but it will fix it for people who do.