### PR TITLE
Correct PojavLauncher link

### DIFF
--- a/how-to-use-altstore/trusted-sources.md
+++ b/how-to-use-altstore/trusted-sources.md
@@ -37,7 +37,7 @@ Trusted Sources are sources that have been reviewed to make sure they meet our s
 
 #### <mark style="color:purple;">PojavLauncher</mark> <a href="#mark-stylecolorpurpleflyingheads-sourcemark" id="mark-stylecolorpurpleflyingheads-sourcemark"></a>
 
-**Link**: [https://alt.crystall1ne.dev](https://provenance-emu.com)
+**Link**: [https://alt.crystall1ne.dev](https://alt.crystall1ne.dev)
 
 **Apps:**
 


### PR DESCRIPTION
The PojavLauncher link is currently pointing to Provenance. This corrects the link